### PR TITLE
Allow users to modify settings by json

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -8,6 +8,7 @@ namespace WindowsTermialTray.Config
         string ExeFilePath { get; set; }
         ModifierKeys ModifierKeys { get; set; }
     }
+
     public class Config
     {
         App[] Apps { get; set; }

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -1,0 +1,15 @@
+﻿using WindowsTermialTray.Keys;
+
+namespace WindowsTermialTray.Config
+{
+    public class App
+    {
+        string ProcessName { get; set; }
+        string ExeFilePath { get; set; }
+        ModifierKeys ModifierKeys { get; set; }
+    }
+    public class Config
+    {
+        App[] Apps { get; set; }
+    }
+}

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -4,13 +4,21 @@ namespace WindowsTermialTray.Config
 {
     public class App
     {
-        string ProcessName { get; set; }
-        string ExeFilePath { get; set; }
-        ModifierKeys ModifierKeys { get; set; }
+        public string ProcessName { get; set; }
+        public string ExeFilePath { get; set; }
+        public ModifierKeys ModifierKeys { get; set; }
+        public System.Windows.Forms.Keys Keys { get; set; }
     }
 
     public class Config
     {
-        App[] Apps { get; set; }
+        public App[] Apps { get; set; }
+    }
+
+    public class DefaultConfig : Config
+    {
+        public new App[] Apps { get; } = new App[] {
+            new App { ProcessName = "WindowsTerminal", ExeFilePath = "wt.exe", ModifierKeys = ModifierKeys.Alt, Keys = System.Windows.Forms.Keys.Oemtilde}
+        };
     }
 }

--- a/Config/ConfigBuilder.cs
+++ b/Config/ConfigBuilder.cs
@@ -15,7 +15,13 @@ namespace WindowsTermialTray.Config
 
         public static ConfigBuilder Create()
         {
-            return new ConfigBuilder(default);
+            return new ConfigBuilder(new List<IProvider> { });
+        }
+
+        public ConfigBuilder AddDefault()
+        {
+            _providers.Add(new DefaultProvider());
+            return new ConfigBuilder(_providers);
         }
 
         public ConfigBuilder AddJsonFile(string jsonPath)

--- a/Config/ConfigBuilder.cs
+++ b/Config/ConfigBuilder.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using WindowsTermialTray.Config.Provider;
+
+namespace WindowsTermialTray.Config
+{
+    // var config = new ConfigBuilder().AddJsonFile("./config.json").AddJsonFile(appPath).Build()
+    public class ConfigBuilder
+    {
+        private class ProviderList
+        {
+            public string filePath;
+            public IProvider provider;
+        }
+
+        private readonly List<ProviderList> _providers;
+
+        private ConfigBuilder(List<ProviderList> providers)
+        {
+            new ConfigBuilder(_providers = providers);
+        }
+
+        public static ConfigBuilder Create()
+        {
+            return new ConfigBuilder(default);
+        }
+
+        public ConfigBuilder AddJsonFile(string jsonPath)
+        {
+            _providers.Add(new ProviderList { filePath = jsonPath, provider = new JsonProvider() });
+            return new ConfigBuilder(_providers);
+        }
+
+        // TODO: call provider.Deserialize() in foreach
+        public Config Build()
+        {
+            return new Config();
+        }
+    }
+}

--- a/Config/ConfigBuilder.cs
+++ b/Config/ConfigBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using WindowsTermialTray.Config.Provider;
 
 namespace WindowsTermialTray.Config
@@ -25,7 +26,12 @@ namespace WindowsTermialTray.Config
 
         public ConfigBuilder AddJsonFile(string jsonPath)
         {
-            _providers.Add(new JsonProvider(jsonPath));
+            if (File.Exists(jsonPath))
+            {
+                var jsonString = File.ReadAllText(jsonPath);
+                _providers.Add(new JsonProvider(jsonString));
+            }
+
             return new ConfigBuilder(_providers);
         }
 

--- a/Config/ConfigBuilder.cs
+++ b/Config/ConfigBuilder.cs
@@ -3,7 +3,6 @@ using WindowsTermialTray.Config.Provider;
 
 namespace WindowsTermialTray.Config
 {
-    // var config = ConfigBuilder.Create().AddJsonFile("./config.json").AddJsonFile(appPath).Build()
     public class ConfigBuilder
     {
         private readonly List<IProvider> _providers;

--- a/Config/ConfigBuilder.cs
+++ b/Config/ConfigBuilder.cs
@@ -6,17 +6,11 @@ namespace WindowsTermialTray.Config
     // var config = new ConfigBuilder().AddJsonFile("./config.json").AddJsonFile(appPath).Build()
     public class ConfigBuilder
     {
-        private class ProviderList
-        {
-            public string filePath;
-            public IProvider provider;
-        }
+        private readonly List<IProvider> _providers;
 
-        private readonly List<ProviderList> _providers;
-
-        private ConfigBuilder(List<ProviderList> providers)
+        private ConfigBuilder(List<IProvider> providers)
         {
-            new ConfigBuilder(_providers = providers);
+            _providers = providers;
         }
 
         public static ConfigBuilder Create()
@@ -26,7 +20,7 @@ namespace WindowsTermialTray.Config
 
         public ConfigBuilder AddJsonFile(string jsonPath)
         {
-            _providers.Add(new ProviderList { filePath = jsonPath, provider = new JsonProvider() });
+            _providers.Add(new JsonProvider(jsonPath));
             return new ConfigBuilder(_providers);
         }
 

--- a/Config/ConfigBuilder.cs
+++ b/Config/ConfigBuilder.cs
@@ -3,7 +3,7 @@ using WindowsTermialTray.Config.Provider;
 
 namespace WindowsTermialTray.Config
 {
-    // var config = new ConfigBuilder().AddJsonFile("./config.json").AddJsonFile(appPath).Build()
+    // var config = ConfigBuilder.Create().AddJsonFile("./config.json").AddJsonFile(appPath).Build()
     public class ConfigBuilder
     {
         private readonly List<IProvider> _providers;
@@ -24,10 +24,21 @@ namespace WindowsTermialTray.Config
             return new ConfigBuilder(_providers);
         }
 
-        // TODO: call provider.Deserialize() in foreach
         public Config Build()
         {
-            return new Config();
+            foreach (var provider in _providers)
+            {
+                var config = provider.Load();
+                if (config != null)
+                {
+                    return config;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            return null;
         }
     }
 }

--- a/Config/Provider/DefaultProvider.cs
+++ b/Config/Provider/DefaultProvider.cs
@@ -1,0 +1,10 @@
+﻿namespace WindowsTermialTray.Config.Provider
+{
+    class DefaultProvider : IProvider
+    {
+        public Config Load()
+        {
+            return new DefaultConfig();
+        }
+    }
+}

--- a/Config/Provider/IProvider.cs
+++ b/Config/Provider/IProvider.cs
@@ -2,6 +2,6 @@
 {
     interface IProvider
     {
-        Config Deserialize(string source);
+        Config Deserialize();
     }
 }

--- a/Config/Provider/IProvider.cs
+++ b/Config/Provider/IProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace WindowsTermialTray.Config.Provider
+{
+    interface IProvider
+    {
+        Config Deserialize(string source);
+    }
+}

--- a/Config/Provider/IProvider.cs
+++ b/Config/Provider/IProvider.cs
@@ -2,6 +2,10 @@
 {
     interface IProvider
     {
-        Config Deserialize();
+        /// <summary>
+        /// Load configurations.
+        /// </summary>
+        /// <exception cref="System.FormatException">Thrown when invalid data provided.</exception>
+        Config Load();
     }
 }

--- a/Config/Provider/JsonProvider.cs
+++ b/Config/Provider/JsonProvider.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace WindowsTermialTray.Config.Provider
 {
-    class JsonProvider : IProvider
+    public class JsonProvider : IProvider
     {
         private readonly string _jsonPath;
 

--- a/Config/Provider/JsonProvider.cs
+++ b/Config/Provider/JsonProvider.cs
@@ -18,7 +18,7 @@ namespace WindowsTermialTray.Config.Provider
             try
             {
                 var config = JsonSerializer.Deserialize<Config>(_jsonString);
-                var hasNull = config.GetType().GetProperties().All(p => p.GetValue(config) != null);
+                var hasNull = config.Apps.Any(a => a.GetType().GetProperties().Any(p => p.GetValue(a) == default));
                 if (hasNull)
                 {
                     throw new FormatException("json includes null value or some fields are missing");

--- a/Config/Provider/JsonProvider.cs
+++ b/Config/Provider/JsonProvider.cs
@@ -1,34 +1,26 @@
 ﻿using System;
-using System.IO;
 using System.Text.Json;
 
 namespace WindowsTermialTray.Config.Provider
 {
     public class JsonProvider : IProvider
     {
-        private readonly string _jsonPath;
+        private readonly string _jsonString;
 
-        public JsonProvider(string jsonPath)
+        public JsonProvider(string jsonString)
         {
-            _jsonPath = jsonPath;
+            _jsonString = jsonString;
         }
 
         public Config Load()
         {
-            if (!File.Exists(_jsonPath))
-            {
-                return null;
-            }
-
-            var jsonString = File.ReadAllText(_jsonPath);
-
             try
             {
-                return JsonSerializer.Deserialize<Config>(jsonString);
+                return JsonSerializer.Deserialize<Config>(_jsonString);
             }
             catch (JsonException e)
             {
-                throw new FormatException($"invalid json: {_jsonPath}", e);
+                throw new FormatException($"invalid json", e);
             }
         }
     }

--- a/Config/Provider/JsonProvider.cs
+++ b/Config/Provider/JsonProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text.Json;
 
 namespace WindowsTermialTray.Config.Provider
@@ -16,7 +17,14 @@ namespace WindowsTermialTray.Config.Provider
         {
             try
             {
-                return JsonSerializer.Deserialize<Config>(_jsonString);
+                var config = JsonSerializer.Deserialize<Config>(_jsonString);
+                var hasNull = config.GetType().GetProperties().All(p => p.GetValue(config) != null);
+                if (hasNull)
+                {
+                    throw new FormatException("json includes null value or some fields are missing");
+                }
+
+                return config;
             }
             catch (JsonException e)
             {

--- a/Config/Provider/JsonProvider.cs
+++ b/Config/Provider/JsonProvider.cs
@@ -4,9 +4,16 @@ namespace WindowsTermialTray.Config.Provider
 {
     class JsonProvider : IProvider
     {
-        public Config Deserialize(string jsonString)
+        private readonly string _jsonString;
+
+        public JsonProvider(string jsonString)
         {
-            return JsonSerializer.Deserialize<Config>(jsonString);
+            _jsonString = jsonString;
+        }
+
+        public Config Deserialize()
+        {
+            return JsonSerializer.Deserialize<Config>(_jsonString);
         }
     }
 }

--- a/Config/Provider/JsonProvider.cs
+++ b/Config/Provider/JsonProvider.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json;
+
+namespace WindowsTermialTray.Config.Provider
+{
+    class JsonProvider : IProvider
+    {
+        public Config Deserialize(string jsonString)
+        {
+            return JsonSerializer.Deserialize<Config>(jsonString);
+        }
+    }
+}

--- a/Config/Provider/JsonProvider.cs
+++ b/Config/Provider/JsonProvider.cs
@@ -1,19 +1,35 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.IO;
+using System.Text.Json;
 
 namespace WindowsTermialTray.Config.Provider
 {
     class JsonProvider : IProvider
     {
-        private readonly string _jsonString;
+        private readonly string _jsonPath;
 
-        public JsonProvider(string jsonString)
+        public JsonProvider(string jsonPath)
         {
-            _jsonString = jsonString;
+            _jsonPath = jsonPath;
         }
 
-        public Config Deserialize()
+        public Config Load()
         {
-            return JsonSerializer.Deserialize<Config>(_jsonString);
+            if (!File.Exists(_jsonPath))
+            {
+                return null;
+            }
+
+            var jsonString = File.ReadAllText(_jsonPath);
+
+            try
+            {
+                return JsonSerializer.Deserialize<Config>(jsonString);
+            }
+            catch (JsonException e)
+            {
+                throw new FormatException($"invalid json: {_jsonPath}", e);
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -73,25 +73,41 @@ If you had multiple instances of an app, Termial Tray will store only one, so fe
 ## FAQ
 
 ### **Can I manage other apps like Windows Terminal with Quake Style?**
-Yes of course! But you need to dig into code. Just download this repo, go to `TerminalTracyIcon.cs` file and find this section:
-```C#
-_appTrayList.AddRange(new []
-            {
-                new TrayApp("WindowsTerminal", "wt.exe", ModifierKeys.Alt, Keys.Oemtilde)
-                // Add your other tray apps here
-                // new TrayApp("ProcessName", "exec.exe", ModifierKeys.Ctrl, Keys.Oemtilde)
-            });
+You can configure settings by `config.json` like below.
+
+#### config.json
+```json
+{
+    "Apps": [
+        {
+            "ProcessName": "WindowsTerminal",
+            "ExeFilePath": "wt.exe",
+            "ModifierKeys": 1,
+            "Keys": 84
+        },
+        {
+            "ProcessName": "Spotify",
+            "ExeFilePath": "Spotify.exe",
+            "ModifierKeys": 1,
+            "Keys": 83
+        }
+    ]
+}
 ```
+The json should be located at:
+1. same directory as `WindowsTermialTray.exe`
+1. `$env:LOCALAPPDATA\WindowsTermialTray\config.json`
+
 From here you can add other apps, but you need to specify and know:
 
 * Your app [ProcessName](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-process?view=powershell-7).
 * Your app executable.
-* Unique pair of `ModifierKey` and `Key`.
-
-When you find out everything - add your app in code with parameters (and comment Windows Terminal if don't want it), and follow steps in [installation section](#installation), to build `.exe` file.
-
-### **Why building and adding other apps is so difficult?**
-Because I didn't prepared this. For now this little app is for me, but if you like it too - tell me, and I'll continue to contribuiting it!
+* Unique pair of `ModifierKey` and [Key](https://docs.microsoft.com/ja-jp/dotnet/api/system.windows.forms.keys).
+#### ModifierKey
+- Alt: 1
+- Control: 2
+- Shift: 4
+- Win: 8
 
 ### **Will you be contributing this Termial Tray?**
 Nah. I hope that MS add *Quake Style* behaviour for Windows Terminal, but if not, or some people find Termial Tray useful for other Jobs - I'll start to work on this app, to make it more powerfull and usefull.

--- a/TerminalTrayIcon.cs
+++ b/TerminalTrayIcon.cs
@@ -39,7 +39,7 @@ namespace WindowsTerminalTray
             }
             catch (FormatException)
             {
-                OpenMessageBox("Settings clouldn't be loaded from file.\nCheck for syntax error, including invalid value.");
+                OpenMessageBox("Settings couldn't be loaded from file.\nCheck for syntax error, including invalid value.");
                 Application.Exit();
             }
 

--- a/TerminalTrayIcon.cs
+++ b/TerminalTrayIcon.cs
@@ -34,7 +34,7 @@ namespace WindowsTerminalTray
             {
                 config = ConfigBuilder.Create()
                     .AddJsonFile(Path.Combine(Environment.CurrentDirectory, configFileName))
-                    .AddJsonFile(Path.Combine(Directory.GetParent(Application.UserAppDataPath).FullName, configFileName))
+                    .AddJsonFile(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Application.ProductName, configFileName))
                     .AddDefault().Build();
             }
             catch (FormatException)

--- a/TerminalTrayIcon.cs
+++ b/TerminalTrayIcon.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Windows.Forms;
 using WindowsTermialTray;
 using WindowsTermialTray.Config;
@@ -27,8 +28,20 @@ namespace WindowsTerminalTray
 
             contextMenu.MenuItems.Add(exitItem);
 
-            var configPath = Application.UserAppDataPath + "\\config.json";
-            var config = ConfigBuilder.Create().AddJsonFile(configPath).AddDefault().Build();
+            var configFileName = "config.json";
+            Config config = null;
+            try
+            {
+                config = ConfigBuilder.Create()
+                    .AddJsonFile(Path.Combine(Environment.CurrentDirectory, configFileName))
+                    .AddJsonFile(Path.Combine(Directory.GetParent(Application.UserAppDataPath).FullName, configFileName))
+                    .AddDefault().Build();
+            }
+            catch (FormatException)
+            {
+                OpenMessageBox("Settings clouldn't be loaded from file.\nCheck for syntax error, including invalid value.");
+                Application.Exit();
+            }
 
             _appTrayList = new List<TrayApp>();
             foreach (var app in config.Apps)
@@ -56,5 +69,10 @@ namespace WindowsTerminalTray
         }
 
         public void Dispose() { }
+
+        private void OpenMessageBox(string message)
+        {
+            MessageBox.Show(message, Application.ProductName);
+        }
     }
 }

--- a/TrayApp.cs
+++ b/TrayApp.cs
@@ -86,7 +86,9 @@ namespace WindowsTermialTray
                 process.StartInfo.FileName = _exec;
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Maximized;
                 process.Start();
-                while (_appProcess == null)
+
+                var start = DateTime.Now;
+                while (_appProcess == null && DateTime.Now - start < TimeSpan.FromMilliseconds(1000))
                 {
                     _appProcess = Process.GetProcesses().FirstOrDefault(x => x.ProcessName.Equals(_processName) && !x.HasExited);
                     Thread.Sleep(100);

--- a/WindowsTermialTray.sln
+++ b/WindowsTermialTray.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsTerminalTray", "WindowsTerminalTray.csproj", "{CBC9BB16-8421-4641-9850-B950D82F4022}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsTerminalTrayTests", "..\WindowsTerminalTrayTests1\WindowsTerminalTrayTests.csproj", "{2525AD03-6AB3-4DA4-8248-8BF22BA22417}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{CBC9BB16-8421-4641-9850-B950D82F4022}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBC9BB16-8421-4641-9850-B950D82F4022}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBC9BB16-8421-4641-9850-B950D82F4022}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WindowsTermialTray.sln
+++ b/WindowsTermialTray.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsTerminalTray", "WindowsTerminalTray.csproj", "{CBC9BB16-8421-4641-9850-B950D82F4022}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsTerminalTrayTests", "..\WindowsTerminalTrayTests1\WindowsTerminalTrayTests.csproj", "{2525AD03-6AB3-4DA4-8248-8BF22BA22417}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTests", "test\UnitTests\UnitTests.csproj", "{B783C3E2-7D28-4217-A915-266562E2C3F5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,10 @@ Global
 		{CBC9BB16-8421-4641-9850-B950D82F4022}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBC9BB16-8421-4641-9850-B950D82F4022}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBC9BB16-8421-4641-9850-B950D82F4022}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2525AD03-6AB3-4DA4-8248-8BF22BA22417}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B783C3E2-7D28-4217-A915-266562E2C3F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B783C3E2-7D28-4217-A915-266562E2C3F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B783C3E2-7D28-4217-A915-266562E2C3F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B783C3E2-7D28-4217-A915-266562E2C3F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WindowsTerminalTray.csproj
+++ b/WindowsTerminalTray.csproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <Compile Include="Config\Config.cs" />
     <Compile Include="Config\ConfigBuilder.cs" />
+    <Compile Include="Config\Provider\DefaultProvider.cs" />
     <Compile Include="Config\Provider\IProvider.cs" />
     <Compile Include="Config\Provider\JsonProvider.cs" />
     <Compile Include="TrayApp.cs" />

--- a/WindowsTerminalTray.csproj
+++ b/WindowsTerminalTray.csproj
@@ -71,6 +71,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\Config.cs" />
+    <Compile Include="Config\ConfigBuilder.cs" />
+    <Compile Include="Config\Provider\IProvider.cs" />
+    <Compile Include="Config\Provider\JsonProvider.cs" />
     <Compile Include="TrayApp.cs" />
     <Compile Include="Keys\KeyboardHook.cs" />
     <Compile Include="Program.cs" />

--- a/WindowsTerminalTray.csproj
+++ b/WindowsTerminalTray.csproj
@@ -58,8 +58,39 @@
     <ApplicationIcon>terminal-tray.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.5.0.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -90,6 +121,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net472" />
+  <package id="System.Text.Json" version="5.0.2" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
+</packages>

--- a/test/UnitTests/Config/Provider/JsonProviderTests.cs
+++ b/test/UnitTests/Config/Provider/JsonProviderTests.cs
@@ -1,0 +1,32 @@
+using WindowsTermialTray.Config.Provider;
+using WindowsTermialTray.Keys;
+using Xunit;
+
+namespace UnitTests
+{
+    public class JsonProviderTests
+    {
+        [Fact]
+        public void LoadFromValidJson()
+        {
+            var json = @"
+{
+    ""Apps"": [
+        {
+            ""ProcessName"": ""Windows Terminal"",
+            ""ExeFilePath"": ""wt.exe"",
+            ""ModifierKeys"": 1,
+            ""Keys"": 192
+        }
+    ]
+}";
+            var jsonProvider = new JsonProvider(json);
+            var config = jsonProvider.Load();
+
+            Assert.Equal("Windows Terminal", config.Apps[0].ProcessName);
+            Assert.Equal("wt.exe", config.Apps[0].ExeFilePath);
+            Assert.Equal(ModifierKeys.Alt, config.Apps[0].ModifierKeys);
+            Assert.Equal(System.Windows.Forms.Keys.Oemtilde, config.Apps[0].Keys);
+        }
+    }
+}

--- a/test/UnitTests/Config/Provider/JsonProviderTests.cs
+++ b/test/UnitTests/Config/Provider/JsonProviderTests.cs
@@ -1,0 +1,62 @@
+using System;
+using WindowsTermialTray.Config.Provider;
+using WindowsTermialTray.Keys;
+using Xunit;
+
+namespace UnitTests
+{
+    public class JsonProviderTests
+    {
+        [Fact]
+        public void LoadFromValidJson()
+        {
+            var json = @"
+{
+    ""Apps"": [
+        {
+            ""ProcessName"": ""Windows Terminal"",
+            ""ExeFilePath"": ""wt.exe"",
+            ""ModifierKeys"": 1,
+            ""Keys"": 192
+        }
+    ]
+}";
+            var jsonProvider = new JsonProvider(json);
+            var config = jsonProvider.Load();
+
+            Assert.Equal("Windows Terminal", config.Apps[0].ProcessName);
+            Assert.Equal("wt.exe", config.Apps[0].ExeFilePath);
+            Assert.Equal(ModifierKeys.Alt, config.Apps[0].ModifierKeys);
+            Assert.Equal(System.Windows.Forms.Keys.Oemtilde, config.Apps[0].Keys);
+        }
+
+        [Fact]
+        public void LoadFromInvalidJson()
+        {
+            var json = @"""test""";
+            var jsonProvider = new JsonProvider(json);
+            var exception = Assert.Throws<FormatException>(
+                () => jsonProvider.Load());
+
+            Assert.NotNull(exception.Message);
+        }
+
+        [Fact]
+        public void LoadFromInvalidJson_MissingFields()
+        {
+            var json = @"
+{
+    ""Apps"": [
+        {
+            ""ProcessName"": ""Windows Terminal""
+        }
+    ]
+}";
+            var jsonProvider = new JsonProvider(json);
+            var exception = Assert.Throws<FormatException>(
+                () => jsonProvider.Load());
+
+            Assert.NotNull(exception.Message);
+        }
+    }
+}

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WindowsTerminalTray.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary of the Pull Request

Currently, users have to modify the source to add apps or change the default setting.
This PR allows users to do that by creating a json file like below:

#### config.json
```json
{
    "Apps": [
        {
            "ProcessName": "WindowsTerminal",
            "ExeFilePath": "wt.exe",
            "ModifierKeys": 1,
            "Keys": 84
        },
        {
            "ProcessName": "Spotify",
            "ExeFilePath": "Spotify.exe",
            "ModifierKeys": 1,
            "Keys": 83
        }
    ]
}
```

The json should be located at:
1. same directory as `WindowsTermialTray.exe`
1. `$env:LOCALAPPDATA\WindowsTermialTray\config.json`

## Checklist
- [x] Implement Config class with builder pattern
- [x] Add a project for unit tests (I'm not familiar with C#, so I followed [Microsoft's docs for unit test](https://docs.microsoft.com/en-us/visualstudio/test/walkthrough-creating-and-running-unit-tests-for-managed-code?view=vs-2019))
- [x] Change default key binding to `T` from `oemtilde` which only available on US Keyboard.

and just a trivial question, which is the correct application name, `TermialTray` or `TerminalTray`? Both of them are found at the source.